### PR TITLE
Added predict fun for keras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ r_github_packages:
 before_install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev
+before-script:
+ - Rscript -e "keras::install_keras()"
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ r_github_packages:
 before_install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev
-before-script:
+before_script:
  - Rscript -e "keras::install_keras()"
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests: randomForest,
           devtools, 
           doParallel,
           ALEPlot,
-          ranger
+          ranger,
+          keras
 License: MIT + file LICENSE
 Encoding: UTF-8
 RoxygenNote: 6.1.1

--- a/R/create_predict_fun.R
+++ b/R/create_predict_fun.R
@@ -84,6 +84,16 @@ create_predict_fun.default = function(model, task, predict.fun = NULL, type = NU
   }
 }
 
+create_predict_fun.keras.engine.training.Model = function(model, task, predict.fun = NULL, type = NULL){
+  if (is.null(predict.fun)) {
+      predict.fun = function(object, newdata) predict(object, newdata)
+  }
+  function(newdata) {
+    pred = do.call(predict.fun, list(model, newdata = as.matrix(newdata)))
+    data.frame(pred)
+  }
+}
+
 
 factor_to_dataframe = function(fac) {
   check_vector(fac)


### PR DESCRIPTION
Added a create_predict_fun implementation for keras. Support both regression and classification (keras always predicts probabilities so no type argument is necessary).
Also added simple unit tests.

Should help with #71 (and indirectly #72 by making it easier to use keras)