### PR TITLE
Fix forwarding of `ncol` and `nrows` arguments to `wrap_plots()`

### DIFF
--- a/R/FeatureEffects.R
+++ b/R/FeatureEffects.R
@@ -205,7 +205,7 @@ FeatureEffects <- R6Class("FeatureEffects",
 
       y_axis_label <- self$effects[[1]]$.__enclos_env__$private$y_axis_label
 
-      patchwork::wrap_plots(plts) +
+      patchwork::wrap_plots(plts, nrow = nrows, ncol = ncols) +
         patchwork::plot_annotation(title = y_axis_label)
     }
   )


### PR DESCRIPTION
Beforehand the arguments of `$plot()` were not forwarded and just silently ignored.

``` r
library("rpart")
library("iml")
data("Boston", package  = "MASS")
rf = rpart(medv ~ ., data = Boston)
mod = Predictor$new(rf, data = Boston)

# Compute the accumulated local effects for all features
eff <- FeatureEffects$new(mod)
eff$plot(ncol = 2)
```

![](https://i.imgur.com/PnEBE5s.png)

<sup>Created on 2020-03-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>