### PR TITLE
Joint feature importance

### DIFF
--- a/man/FeatureImp.Rd
+++ b/man/FeatureImp.Rd
@@ -80,6 +80,18 @@ imp <- FeatureImp$new(mod, loss = "mae", compare = "difference")
 # Plot the results directly
 plot(imp)
 
+# We can calculate feature importance for a subset of features 
+imp <- FeatureImp$new(mod, loss = "mae", features = c("crim", "zn", "indus"))
+plot(imp)
+
+# We can calculate joint importance of groups of features
+groups = list(
+ grp1 = c("crim", "zn", "indus", "chas"),
+ grp2 = c("nox", "rm", "age", "dis"),
+ grp3 = c("rad", "tax", "ptratio", "black", "lstat")
+)
+imp <- FeatureImp$new(mod, loss = "mae", features = groups)
+plot(imp)
 
 # FeatureImp also works with multiclass classification.
 # In this case, the importance measurement regards all classes
@@ -127,6 +139,10 @@ Number of repetitions.}
 depending on whether the importance was calculated as difference
 between original model error and model error after permutation or as
 ratio.}
+
+\item{\code{features}}{(\code{list})\cr Features for which importance scores are to
+be calculated. The names are the feature/group names, while the contents
+specify which feature(s) are to be permuted.}
 }
 \if{html}{\out{</div>}}
 }
@@ -151,7 +167,13 @@ ratio.}
 \subsection{Method \code{new()}}{
 Create a FeatureImp object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FeatureImp$new(predictor, loss, compare = "ratio", n.repetitions = 5)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImp$new(
+  predictor,
+  loss,
+  compare = "ratio",
+  n.repetitions = 5,
+  features = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -179,6 +201,12 @@ original model error and model error after permutation?
 How often should the shuffling of the feature be repeated?
 The higher the number of repetitions the more stable and accurate the
 results become.}
+
+\item{\code{features}}{(\verb{character or list})\cr
+For which features do you want importance scores calculated. The default
+value of \code{NULL} implies all features. Use a named list of character vectors
+to define groups of features for which joint importance will be calculated.
+See examples.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-FeatureImp.R
+++ b/tests/testthat/test-FeatureImp.R
@@ -140,3 +140,49 @@ test_that("Feature Importance 0", {
   fimp <- FeatureImp$new(pred, loss = "mae", n.repetitions = 3)
   expect_equal(fimp$results$importance[3], 1)
 })
+
+test_that("FeatureImp works for a subset of features", {
+  var.imp <- FeatureImp$new(predictor1, loss = "mse", features = c("a", "b"))
+  dat <- var.imp$results
+  expect_class(dat, "data.frame")
+  expect_false("data.table" %in% class(dat))
+  expect_equal(colnames(dat), expected_colnames)
+  expect_equal(nrow(dat), 2)
+  p <- plot(var.imp)
+  expect_s3_class(p, c("gg", "ggplot"))
+  p
+})
+
+test_that("Invalid feature names are caught", {
+  expect_error(
+    FeatureImp$new(predictor1, loss = "mse", features = c("x", "y", "z")),
+    "failed: Must be a subset of {'a','b','c','d'}, but is {'x','y','z'}",
+    fixed = TRUE
+  )
+})
+
+test_that("FeatureImp works for groups of features", {
+  groups = list(ab = c("a", "b"), cd = c("c", "d"))
+  var.imp <- FeatureImp$new(predictor1, loss = "mse", features = groups)
+  dat <- var.imp$results
+  expect_class(dat, "data.frame")
+  expect_false("data.table" %in% class(dat))
+  expect_equal(colnames(dat), expected_colnames)
+  expect_equal(nrow(dat), 2)
+  p <- plot(var.imp)
+  expect_s3_class(p, c("gg", "ggplot"))
+  p
+})
+
+test_that("FeatureImp works for overlapping groups of features", {
+  groups = list(ab = c("a", "b"), bc = c("b", "c"))
+  var.imp <- FeatureImp$new(predictor1, loss = "mse", features = groups)
+  dat <- var.imp$results
+  expect_class(dat, "data.frame")
+  expect_false("data.table" %in% class(dat))
+  expect_equal(colnames(dat), expected_colnames)
+  expect_equal(nrow(dat), 2)
+  p <- plot(var.imp)
+  expect_s3_class(p, c("gg", "ggplot"))
+  p
+})


### PR DESCRIPTION
**Motivation**
Sometimes features have a natural grouping, for example are sourced from a specific data provider. It is therefore usefull to know the joint importance of group(s) of features. Maybe that data provider is very expensive and you want to decide on a cost/benefit basis if you can drop those features from your model.

Additionally, for large datasets, the feature importance calculation is computationally expensive. It would therefore be useful to specify which features you want importance scores calculated on rather than have to calculate the full set.

**Implementation**
This PR adds an argument `features` to the `FeatureImp$new` call. It works as follows:

- If `NULL` (the default) behavior is unchanged. i.e. scores are calculated for all features individually.
- If a character vector of feature names, scores are calculated only for that subset of features.
- If a list of character vectors, then joint importance of each group is calculated.
