### PR TITLE
Fix FeatureEffect handling of empty levels

### DIFF
--- a/R/FeatureEffect-ale.R
+++ b/R/FeatureEffect-ale.R
@@ -223,7 +223,7 @@ calculate.ale.cat <- function(dat, run.prediction, feature.name) {
   # The new order of the levels
   levels.ordered <- levels.original[level_order]
   # The feature with the levels in the new order
-  x.ordered <- order(level_order)[as.numeric(x)]
+  x.ordered <- order(level_order)[as.numeric(droplevels(x))]
   X.lower <- X.upper <- dat
 
   # We only want to increase/decrease the ones that are not already the minimum or maximum level

--- a/tests/testthat/test-FeatureEffect.R
+++ b/tests/testthat/test-FeatureEffect.R
@@ -727,7 +727,7 @@ test_that("method='ale' in case of single category as well", {
 test_that("FeatureEffect handles empty level", {
   set.seed(123)
   dat <- data.frame(y = 1:10, x = factor(c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2),
-    levels = c(1, 2, 3)
+    levels = c(3, 2, 1)
   ), xx = rnorm(10))
   mod <- lm(y ~ x, data = dat)
   pred <- Predictor$new(mod, data = dat)


### PR DESCRIPTION
**Motivation**

`FeatureEffect` does not handle empty levels correctly. The existing test missed this bug because it was only testing the special case where the last level is empty.

**Implementation**

Fixed by adding the missing `droplevels(x)`. It may be cleaner to add a line `x <- droplevels(x)` immediately after x is created, and then remove all the `droplevels(x)` statements elsewhere.

The test was updated to catch the bug by simply reversing the order of the levels.