### PR TITLE
Enhance documentation for LocalModel

### DIFF
--- a/R/LocalModel.R
+++ b/R/LocalModel.R
@@ -16,6 +16,12 @@
 #' binarized, depending on the category of the instance to be explained: 1 if
 #' the category is the same, 0 otherwise.
 #'
+#' Please note that scaling continuous features in the machine learning method
+#' might be advisable when using LIME as an interpretation technique. LIME uses
+#' a distance measure to compute proximity weights for the weighted glm. Hence,
+#' the original scale of the features may influence the distance measure and
+#' therewith LIME results.
+#'
 #' To learn more about local models, read the Interpretable Machine Learning
 #' book: \url{https://christophm.github.io/interpretable-ml-book/lime.html}
 #'


### PR DESCRIPTION
The range and standard deviation of the features has a huge influence on the distance measure (distance between the data and the interest of interest) and therewith lime results when the LocalModel function is used. This is also discussed, e.g., in [this stackoverflow thread](https://stats.stackexchange.com/questions/89809/is-it-important-to-scale-data-before-clustering#89813) for clustering analyses. 

In the lime package by Pedersen and Bernesty, features are scaled before the distance measure is computed. However, there might be reasons where scaling is not desired, e.g., when features have some kind of natural scale. But I think it would at least be a good idea to inform the iml user that scaling the features might be advisable when they want to use lime as an interpretation technique as scaling can influence the computed distance. Therefore, I added this text to the documentation of the LocalModel function, so users can decide themselves whether they would like to scale their features or get more information about the topic. 

Thanks for providing and taking care of this package! 
Mirka