### PR TITLE
Add gower.power argument to LocalModel

### DIFF
--- a/R/LocalModel.R
+++ b/R/LocalModel.R
@@ -251,7 +251,7 @@ LocalModel <- R6Class("LocalModel",
       if (dist.fun == "gower") {
         require("gower")
         function(X, x.interest) {
-          (1 - gower_dist(X, x.interest))^gower.power
+          1 - (gower_dist(X, x.interest))^gower.power
         }
       } else if (is.character(dist.fun)) {
         assert_numeric(kernel.width)

--- a/R/LocalModel.R
+++ b/R/LocalModel.R
@@ -129,7 +129,7 @@ LocalModel <- R6Class("LocalModel",
       if (!is.null(x.interest)) {
         self$x.interest <- private$match_cols(x.interest)
       }
-      private$weight.fun <- private$get.weight.fun(dist.fun, kernel.width)
+      private$weight.fun <- private$get.weight.fun(dist.fun, kernel.width, gower.power)
 
       if (!is.null(x.interest)) private$run()
     },
@@ -247,9 +247,10 @@ LocalModel <- R6Class("LocalModel",
       if (private$multiClass) p <- p + facet_wrap(".class")
       p
     },
-    get.weight.fun = function(dist.fun, kernel.width) {
+    get.weight.fun = function(dist.fun, kernel.width, gower.power) {
       if (dist.fun == "gower") {
         require("gower")
+        assert_numeric(gower.power)
         function(X, x.interest) {
           1 - (gower_dist(X, x.interest))^gower.power
         }

--- a/R/LocalModel.R
+++ b/R/LocalModel.R
@@ -100,6 +100,10 @@ LocalModel <- R6Class("LocalModel",
     #'   The name of the distance function for computing proximities (weights in
     #'   the linear model). Defaults to `"gower"`. Otherwise will be forwarded
     #'   to [stats::dist].
+    #' @param gower.power (`numeric(1)`)\cr
+    #'   The calculated gower proximity will be raised to the power of this
+    #'   value. Can be used to specify the size of the neighborhood for the
+    #'   LocalModel (similar to kernel.width for the euclidean distance).
     #' @param kernel.width (`numeric(1)`)\cr
     #'   The width of the kernel for the proximity computation.
     #'   Only used if dist.fun is not `"gower"`.
@@ -109,7 +113,7 @@ LocalModel <- R6Class("LocalModel",
     #'   Results with the feature names (`feature`) and contributions to the
     #'   prediction.
     initialize = function(predictor, x.interest, dist.fun = "gower",
-                          kernel.width = NULL, k = 3) {
+                          gower.power = 1, kernel.width = NULL, k = 3) {
 
       assert_number(k, lower = 1, upper = predictor$data$n.features)
       assert_data_frame(x.interest, null.ok = TRUE)
@@ -247,7 +251,7 @@ LocalModel <- R6Class("LocalModel",
       if (dist.fun == "gower") {
         require("gower")
         function(X, x.interest) {
-          1 - gower_dist(X, x.interest)
+          (1 - gower_dist(X, x.interest))^gower.power
         }
       } else if (is.character(dist.fun)) {
         assert_numeric(kernel.width)

--- a/tests/testthat/test-LocalModel.R
+++ b/tests/testthat/test-LocalModel.R
@@ -78,6 +78,7 @@ test_that("LocalModel prediction expects same cols as training dat", {
 
 test_that("LocalModel distance functions work as expected", {
   kernel.width <- 1
+  gower.power <- 1
   distance.functions <- c(
     "gower", "euclidean", "maximum",
     "manhattan", "canberra", "binary", "minkowski")
@@ -95,7 +96,7 @@ test_that("LocalModel distance functions work as expected", {
   # test all distance functions by explicitly constructing them via get.weight.fun()
   for(fun in distance.functions){
     weight_fun <- LocalModel1$.__enclos_env__$private$get.weight.fun(
-      dist.fun = fun, kernel.width = kernel.width)
+      dist.fun = fun, kernel.width = kernel.width, gower.power = gower.power)
     expect_equal(object = weight_fun(X.recode, x.recoded)[2], expected = 1)
   }
 })


### PR DESCRIPTION
For LIME results, it is very sensible to define the neighborhood around the instance of interest. Although the gower distance does not require some kernel width to tune, I think users should have the option to reduce or enlarge the neighborhood that is used for LIME when the gower distance is used (as is for instance possible in the lime package). 

So I added the gower.power argument to the LocalModel function that raises the gower proximity to its power. However, to ensure backward compatibility for now, I specified a default value for gower.power of 1. 

See [here](https://github.com/cran/lime/blob/a8ae937250fdd156971addfe4af31402997d831a/R/a_dataframe.R#L132) for the implementation in the lime package. 