### PR TITLE
Bugfix w.r.t. issue #185 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -146,7 +146,8 @@ get.grid <- function(dat, grid.size, anchor.value = NULL, type = "equidist") {
   assert_data_frame(dat, min.cols = 1)
   features <- colnames(dat)
   feature.type <- unlist(lapply(dat, function(x) {
-    get.feature.type(class(x))
+    # old: get.feature.type(class(x))
+    get.feature.type(class(x)[1])
   }))
   assert_character(features, min.len = 1, max.len = 2)
   assert_true(length(features) == length(feature.type))


### PR DESCRIPTION
Hi Christoph,

the PR hopefully fixes issue #185 (which results from issue no.12 in github.com/LamaTe/mlr3shiny/). 
The problem ist that ordered factors have two classes (ordered and factor) which results in an error when the function get.feature.type() is called within get.grid() (file utils.R).

It would be great if you could check and merge the PR such that we can close the related issue in our package.
Gero

