### PR TITLE
Test fixes and documentation updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,4 +69,4 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Imports:
 Suggests:
     ALEPlot,
     bench,
+    bit64,
     caret,
     covr,
     e1071,

--- a/iml.Rproj
+++ b/iml.Rproj
@@ -14,6 +14,7 @@ LaTeX: pdfLaTeX
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran --no-tests --no-build-vignettes
 PackageRoxygenize: rd,collate,namespace

--- a/man-roxygen/grid.points.R
+++ b/man-roxygen/grid.points.R
@@ -1,0 +1,5 @@
+#' @param grid.points (`numeric()` | `list(numeric()`, `numeric()`)\cr
+#'   An optional grid along the feature. If grid.points are set, the grid.size 
+#'   argument is ignored. Provide a list of two vectors with the same order as 
+#'   in the 'feature' argument, if PDP/ALE for two features is to be computed
+#'   with a user-defined grid.

--- a/man/FeatureEffect.Rd
+++ b/man/FeatureEffect.Rd
@@ -220,7 +220,7 @@ features.}
 \item{\code{grid.size}}{(\code{numeric(1)} | \code{numeric(2)})\cr
 The size of the grid for evaluating the predictions.}
 
-\item{\code{grid.points}}{(\code{numeric() | list(numeric(), numeric())})\cr
+\item{\code{grid.points}}{(\code{numeric()} | \verb{list(numeric()}, \code{numeric()})\cr
 An optional grid along the feature. If grid.points are set, the grid.size
 argument is ignored. Provide a list of two vectors with the same order as
 in the 'feature' argument, if PDP/ALE for two features is to be computed

--- a/man/FeatureEffects.Rd
+++ b/man/FeatureEffects.Rd
@@ -21,7 +21,7 @@ features, directly use \link{FeatureEffect}.
 Parallelization is supported via package \CRANpkg{future}.
 To initialize future-based parallelization, select an appropriate backend and
 specify the amount of workers.
-For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="r">}}\preformatted{future::plan(multisession, workers = 2)
+For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="sourceCode r">}}\preformatted{future::plan(multisession, workers = 2)
 <iml function here>
 }\if{html}{\out{</div>}}
 

--- a/man/FeatureImp.Rd
+++ b/man/FeatureImp.Rd
@@ -39,7 +39,7 @@ See \code{library(help = "Metrics")} to get a list of functions.
 Parallelization is supported via package \CRANpkg{future}.
 To initialize future-based parallelization, select an appropriate backend and
 specify the amount of workers.
-For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="r">}}\preformatted{future::plan(multisession, workers = 2)
+For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="sourceCode r">}}\preformatted{future::plan(multisession, workers = 2)
 <iml function here>
 }\if{html}{\out{</div>}}
 

--- a/man/Interaction.Rd
+++ b/man/Interaction.Rd
@@ -37,7 +37,7 @@ To learn more about interaction effects, read the Interpretable Machine Learning
 Parallelization is supported via package \CRANpkg{future}.
 To initialize future-based parallelization, select an appropriate backend and
 specify the amount of workers.
-For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="r">}}\preformatted{future::plan(multisession, workers = 2)
+For example, to use a PSOCK based cluster backend do:\if{html}{\out{<div class="sourceCode r">}}\preformatted{future::plan(multisession, workers = 2)
 <iml function here>
 }\if{html}{\out{</div>}}
 

--- a/man/LocalModel.Rd
+++ b/man/LocalModel.Rd
@@ -19,6 +19,12 @@ model, which is only valid for that one point. Categorical features are
 binarized, depending on the category of the instance to be explained: 1 if
 the category is the same, 0 otherwise.
 
+Please note that scaling continuous features in the machine learning method
+might be advisable when using LIME as an interpretation technique. LIME uses
+a distance measure to compute proximity weights for the weighted glm. Hence,
+the original scale of the features may influence the distance measure and
+therewith LIME results.
+
 To learn more about local models, read the Interpretable Machine Learning
 book: \url{https://christophm.github.io/interpretable-ml-book/lime.html}
 
@@ -138,6 +144,7 @@ Create a Local Model object.
   predictor,
   x.interest,
   dist.fun = "gower",
+  gower.power = 1,
   kernel.width = NULL,
   k = 3
 )}\if{html}{\out{</div>}}
@@ -157,6 +164,11 @@ Single row with the instance to be explained.}
 The name of the distance function for computing proximities (weights in
 the linear model). Defaults to \code{"gower"}. Otherwise will be forwarded
 to \link[stats:dist]{stats::dist}.}
+
+\item{\code{gower.power}}{(\code{numeric(1)})\cr
+The calculated gower proximity will be raised to the power of this
+value. Can be used to specify the size of the neighborhood for the
+LocalModel (similar to kernel.width for the euclidean distance).}
 
 \item{\code{kernel.width}}{(\code{numeric(1)})\cr
 The width of the kernel for the proximity computation.

--- a/tests/testthat/test-FeatureImp.R
+++ b/tests/testthat/test-FeatureImp.R
@@ -154,7 +154,7 @@ test_that("FeatureImp works for a subset of features", {
 test_that("Invalid feature names are caught", {
   expect_error(
     FeatureImp$new(predictor1, loss = "mse", features = c("x", "y", "z")),
-    "failed: Must be a subset of {'a','b','c','d'}, but is {'x','y','z'}",
+    "failed: Must be a subset of {'a','b','c','d'}, but has additional elements {'x','y','z'}",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-LocalModel.R
+++ b/tests/testthat/test-LocalModel.R
@@ -3,7 +3,7 @@ expected.colnames <- c("beta", "x.recoded", "effect", "x.original", "feature", "
 
 test_that("LocalModel works for single output and single feature", {
   x.interest <- X[2, ]
-  k <- 2
+  k <- 1
   set.seed(42)
   LocalModel1 <- LocalModel$new(predictor1, x.interest = x.interest, k = k)
   dat <- LocalModel1$results


### PR DESCRIPTION
@christophM 

Some small test fixes:

- data.table now wants to have bit64 to be installed
- Silenced a warning complaining about a too large `k` value in a test
- Fixed a failed test because the underlying expectation wording did not match anymore

In addition the roxygen template `grid.points` was missing entirely and for some reason not caught before. I've added it now and roxygenized again. The content was taken from existing content of a `man/` file.

